### PR TITLE
[Fix] 기기별 탭바크기 및 해상도 대응

### DIFF
--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		471940D32CAFEE5B00426D30 /* Font+Uikit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471940D22CAFEE5B00426D30 /* Font+Uikit.swift */; };
 		4736719F2CB120A600527896 /* WeeklyStudy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736719E2CB120A600527896 /* WeeklyStudy.swift */; };
 		473671A12CB1234800527896 /* TodayWiseSaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473671A02CB1234800527896 /* TodayWiseSaying.swift */; };
+		473671A52CB13D8100527896 /* SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473671A42CB13D8100527896 /* SafeArea.swift */; };
 		475B86DD2CA1AEF7000534B2 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B86DC2CA1AEF7000534B2 /* HomeView.swift */; };
 		475B86DF2CA1AF1E000534B2 /* RecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B86DE2CA1AF1E000534B2 /* RecordView.swift */; };
 		475B86E12CA1AF31000534B2 /* RankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B86E02CA1AF31000534B2 /* RankingView.swift */; };
@@ -86,6 +87,7 @@
 		4736719C2CB10D7B00527896 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4736719E2CB120A600527896 /* WeeklyStudy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStudy.swift; sourceTree = "<group>"; };
 		473671A02CB1234800527896 /* TodayWiseSaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWiseSaying.swift; sourceTree = "<group>"; };
+		473671A42CB13D8100527896 /* SafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeArea.swift; sourceTree = "<group>"; };
 		475B86DC2CA1AEF7000534B2 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		475B86DE2CA1AF1E000534B2 /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
 		475B86E02CA1AF31000534B2 /* RankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingView.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 				47BACCF62CA164BA00295DAC /* Font+.swift */,
 				471940D22CAFEE5B00426D30 /* Font+Uikit.swift */,
 				471940D02CAFE61A00426D30 /* LineHeight.swift */,
+				473671A42CB13D8100527896 /* SafeArea.swift */,
 			);
 			path = Basic;
 			sourceTree = "<group>";
@@ -651,6 +654,7 @@
 				47A1477E2CA159E300A91F66 /* SplashView.swift in Sources */,
 				475B86E32CA1AF40000534B2 /* SettingView.swift in Sources */,
 				475B86E52CA1CA61000534B2 /* HY2Button.swift in Sources */,
+				473671A52CB13D8100527896 /* SafeArea.swift in Sources */,
 				471940C82CAFCB1B00426D30 /* SizeCheckModifier.swift in Sources */,
 				47B1D4AC2C9CB1740071B62B /* HongikYeolgong2App.swift in Sources */,
 				475B86E72CA1CC20000534B2 /* HY2TextField.swift in Sources */,

--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4736719F2CB120A600527896 /* WeeklyStudy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4736719E2CB120A600527896 /* WeeklyStudy.swift */; };
 		473671A12CB1234800527896 /* TodayWiseSaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473671A02CB1234800527896 /* TodayWiseSaying.swift */; };
 		473671A52CB13D8100527896 /* SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473671A42CB13D8100527896 /* SafeArea.swift */; };
+		473671A72CB1404E00527896 /* Ratio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473671A62CB1404E00527896 /* Ratio.swift */; };
 		475B86DD2CA1AEF7000534B2 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B86DC2CA1AEF7000534B2 /* HomeView.swift */; };
 		475B86DF2CA1AF1E000534B2 /* RecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B86DE2CA1AF1E000534B2 /* RecordView.swift */; };
 		475B86E12CA1AF31000534B2 /* RankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475B86E02CA1AF31000534B2 /* RankingView.swift */; };
@@ -88,6 +89,7 @@
 		4736719E2CB120A600527896 /* WeeklyStudy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStudy.swift; sourceTree = "<group>"; };
 		473671A02CB1234800527896 /* TodayWiseSaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWiseSaying.swift; sourceTree = "<group>"; };
 		473671A42CB13D8100527896 /* SafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeArea.swift; sourceTree = "<group>"; };
+		473671A62CB1404E00527896 /* Ratio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratio.swift; sourceTree = "<group>"; };
 		475B86DC2CA1AEF7000534B2 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		475B86DE2CA1AF1E000534B2 /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
 		475B86E02CA1AF31000534B2 /* RankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingView.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 				471940D22CAFEE5B00426D30 /* Font+Uikit.swift */,
 				471940D02CAFE61A00426D30 /* LineHeight.swift */,
 				473671A42CB13D8100527896 /* SafeArea.swift */,
+				473671A62CB1404E00527896 /* Ratio.swift */,
 			);
 			path = Basic;
 			sourceTree = "<group>";
@@ -644,6 +647,7 @@
 				47A147482CA13F7A00A91F66 /* StudyRoomUsageRepository.swift in Sources */,
 				47A147402CA13EDD00A91F66 /* StudyRoomUsage.swift in Sources */,
 				471940CB2CAFD9B700426D30 /* RankingCell.swift in Sources */,
+				473671A72CB1404E00527896 /* Ratio.swift in Sources */,
 				475B86E92CA1CD10000534B2 /* Alert.swift in Sources */,
 				47BACCF72CA164BA00295DAC /* Font+.swift in Sources */,
 				471940D32CAFEE5B00426D30 /* Font+Uikit.swift in Sources */,

--- a/HongikYeolgong2/Presentation/Home/HomeView.swift
+++ b/HongikYeolgong2/Presentation/Home/HomeView.swift
@@ -16,7 +16,7 @@ struct HomeView: View {
                 .padding(.top, 120.adjustToScreenHeight)
             
             Spacer()
-            Spacer()
+            
             HStack(spacing: 12.adjustToScreenWidth) {
                 Button(action: {}) {
                     Text("좌석")
@@ -40,9 +40,9 @@ struct HomeView: View {
                     .resizable()
                     .frame(maxWidth: .infinity,
                            minHeight: 52.adjustToScreenHeight))
-            }
+            }   
+            .padding(.bottom, 36.adjustToScreenHeight)
             
-            Spacer()
         }
         .padding(.horizontal, 32.adjustToScreenWidth)
         .background(

--- a/HongikYeolgong2/Presentation/Home/HomeView.swift
+++ b/HongikYeolgong2/Presentation/Home/HomeView.swift
@@ -17,27 +17,29 @@ struct HomeView: View {
             
             Spacer()
             Spacer()
-            HStack(spacing: 12) {
+            HStack(spacing: 12.adjustToScreenWidth) {
                 Button(action: {}) {
                     Text("좌석")
-                        .frame(maxWidth: 69, minHeight: 52)
+                        .frame(maxWidth: 69, minHeight: 52.adjustToScreenHeight)
                         .font(.suite(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
                 }
-                .background(Image(.seatButton).resizable().frame(maxWidth: .infinity, minHeight: 52))
+                .background(Image(.seatButton).resizable().frame(maxWidth: .infinity, minHeight: 52.adjustToScreenHeight))
                 
                 Button(action: {}) {
                     Text("열람실 이용 시작")
-                        .frame(maxWidth: .infinity, minHeight: 52)
+                        .frame(maxWidth: .infinity, 
+                               minHeight: 52.adjustToScreenHeight)
                         .font(.suite(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
                 }
-                .background(Image(.startButton).resizable().frame(maxWidth: .infinity, minHeight: 52))
+                .background(Image(.startButton).resizable().frame(maxWidth: .infinity, 
+                                                                  minHeight: 52.adjustToScreenHeight))
             }
             
             Spacer()
         }
-        .padding(.horizontal, 32)
+        .padding(.horizontal, 32.adjustToScreenWidth)
         .background(
             Image(.iOSBackground)
                 .resizable()

--- a/HongikYeolgong2/Presentation/Home/HomeView.swift
+++ b/HongikYeolgong2/Presentation/Home/HomeView.swift
@@ -13,28 +13,33 @@ struct HomeView: View {
             WeeklyStudy()
             
             TodayWiseSaying()
-                .padding(.top, 120)
+                .padding(.top, 120.adjustToScreenHeight)
             
             Spacer()
             Spacer()
             HStack(spacing: 12.adjustToScreenWidth) {
                 Button(action: {}) {
                     Text("좌석")
-                        .frame(maxWidth: 69, minHeight: 52.adjustToScreenHeight)
+                        .frame(width: 69.adjustToScreenWidth, height: 52.adjustToScreenHeight)
                         .font(.suite(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
                 }
-                .background(Image(.seatButton).resizable().frame(maxWidth: .infinity, minHeight: 52.adjustToScreenHeight))
+                .background(Image(.seatButton)
+                    .resizable()
+                    .frame(maxWidth: .infinity,
+                           minHeight: 52.adjustToScreenHeight))
                 
                 Button(action: {}) {
                     Text("열람실 이용 시작")
-                        .frame(maxWidth: .infinity, 
+                        .frame(maxWidth: .infinity,
                                minHeight: 52.adjustToScreenHeight)
                         .font(.suite(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
                 }
-                .background(Image(.startButton).resizable().frame(maxWidth: .infinity, 
-                                                                  minHeight: 52.adjustToScreenHeight))
+                .background(Image(.startButton)
+                    .resizable()
+                    .frame(maxWidth: .infinity,
+                           minHeight: 52.adjustToScreenHeight))
             }
             
             Spacer()
@@ -43,8 +48,8 @@ struct HomeView: View {
         .background(
             Image(.iOSBackground)
                 .resizable()
-                .frame(maxWidth: .infinity)
                 .ignoresSafeArea(.all)
+                .frame(maxWidth: .infinity, minHeight: SafeAreaHelper.getFullScreenHeight())
                 .allowsHitTesting(false)
         )
     }

--- a/HongikYeolgong2/Presentation/Ranking/Component/RankingCell.swift
+++ b/HongikYeolgong2/Presentation/Ranking/Component/RankingCell.swift
@@ -19,7 +19,7 @@ struct RankingCell: View {
                         .foregroundStyle(setFontColor)
                     
                     Text("건축학부")
-                        .font(.pretendard(size: 16, weight: .regular), lineHeight: 26)
+                        .font(.pretendard(size: 16, weight: .regular), lineHeight: 26.adjustToScreenHeight)
                         .foregroundStyle(setFontColor)
                 }
                 

--- a/HongikYeolgong2/Presentation/Root/MainTabView.swift
+++ b/HongikYeolgong2/Presentation/Root/MainTabView.swift
@@ -91,13 +91,13 @@ struct TabBarView: View {
                 Spacer()
                 
                 ForEach(Tab.allCases, id: \.hashValue) { tab in
-                    VStack(spacing: 5) {
+                    VStack(spacing: 5.adjustToScreenHeight) {
                         Image(tab == selectedTab ? tab.iconNameSelected : tab.iconName, bundle: nil)
                         
                         Text(tab.title)
                             .font(.pretendard(size: 12, weight: .regular))
                             .foregroundStyle(tab == selectedTab ? .gray100 : .gray300)
-                            .frame(height: 18)
+                            .frame(height: 18.adjustToScreenHeight)
                     }
                     .frame(maxWidth: .infinity)
                     .contentShape(Rectangle())
@@ -108,8 +108,8 @@ struct TabBarView: View {
                     Spacer()
                 }
             }
-            .padding(.top, 12)
-            .padding(.horizontal, 20)
+            .padding(.top, 12.adjustToScreenHeight)
+            .padding(.horizontal, 20.adjustToScreenWidth)
             Spacer()
         }
         .frame(height: SafeAreaHelper.getBarBarHeight())

--- a/HongikYeolgong2/Presentation/Root/MainTabView.swift
+++ b/HongikYeolgong2/Presentation/Root/MainTabView.swift
@@ -113,7 +113,7 @@ struct TabBarView: View {
             .padding(.horizontal, 20)
             Spacer()
         }
-        .frame(height: 88)
+        .frame(height: 56 + SafeAreaHelper.safeAreaBottomInset())
         .background(Image(.tabview)
             .resizable()
             .frame(maxWidth: .infinity))

--- a/HongikYeolgong2/Presentation/Root/MainTabView.swift
+++ b/HongikYeolgong2/Presentation/Root/MainTabView.swift
@@ -55,14 +55,13 @@ enum Tab: CaseIterable {
 
 struct MainTabView: View {
     @State private var selectedTab: Tab = .home
-    
+
     var body: some View {
         ZStack(alignment: .bottom) {
             Color.dark.ignoresSafeArea(.all)
             
             VStack {
                 Spacer()
-                
                 switch selectedTab {
                 case .home:
                     HomeView()
@@ -73,9 +72,9 @@ struct MainTabView: View {
                 case .setting:
                     SettingView()
                 }
-                
                 Spacer()
-            }            
+            }
+            .padding(.bottom, SafeAreaHelper.getBarBarHeight())
             
             TabBarView(selectedTab: $selectedTab)
         }
@@ -113,7 +112,7 @@ struct TabBarView: View {
             .padding(.horizontal, 20)
             Spacer()
         }
-        .frame(height: 56 + SafeAreaHelper.safeAreaBottomInset())
+        .frame(height: SafeAreaHelper.getBarBarHeight())
         .background(Image(.tabview)
             .resizable()
             .frame(maxWidth: .infinity))

--- a/HongikYeolgong2/UI/Basic/Ratio.swift
+++ b/HongikYeolgong2/UI/Basic/Ratio.swift
@@ -1,0 +1,20 @@
+//
+//  Ratio.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 10/5/24.
+//
+
+import SwiftUI
+
+extension Double {
+    var adjustToScreenWidth: Double {
+        let ratio: Double = Double(UIScreen.main.bounds.width / 375)
+        return self * ratio
+    }
+    
+    var adjustToScreenHeight: Double {
+        let ratio: Double = Double(UIScreen.main.bounds.height / 812)
+        return self * ratio
+    }
+}

--- a/HongikYeolgong2/UI/Basic/SafeArea.swift
+++ b/HongikYeolgong2/UI/Basic/SafeArea.swift
@@ -10,6 +10,9 @@ import UIKit
 final class SafeAreaHelper {
     private init() {}
     
+    
+    /// 상단 safeArea 크기를 가져옵니다.
+    /// - Returns: CGFloat
     static func safeAreaBottomInset() -> CGFloat {
         if #available(iOS 11.0, *) {
             let window = UIApplication.shared.keyWindow
@@ -20,6 +23,9 @@ final class SafeAreaHelper {
         }
     }
     
+    
+    /// 하단 safeArea 크기를 가져옵니다.
+    /// - Returns: CGFloat
     static func safeAreaTopInset() -> CGFloat {
         if #available(iOS 11.0, *) {
             let window = UIApplication.shared.keyWindow
@@ -30,7 +36,18 @@ final class SafeAreaHelper {
         }
     }
     
+    
+    /// SafeArea를 포함한 스크린높이를 가져옵니다.
+    /// - Returns: CGFloat
     static func getFullScreenHeight() -> CGFloat {
         return UIScreen.main.bounds.height + safeAreaBottomInset() + safeAreaTopInset()
+    }
+    
+    
+    /// 현재 기기에 적용된  탭바의 높이를 가져옵니다.
+    /// - Returns: CGFloat
+    static func getBarBarHeight() -> CGFloat {
+        let defaultTabBarHeight = 56.adjustToScreenHeight
+        return defaultTabBarHeight + safeAreaBottomInset()
     }
 }

--- a/HongikYeolgong2/UI/Basic/SafeArea.swift
+++ b/HongikYeolgong2/UI/Basic/SafeArea.swift
@@ -10,7 +10,6 @@ import UIKit
 final class SafeAreaHelper {
     private init() {}
     
-    
     /// 상단 safeArea 크기를 가져옵니다.
     /// - Returns: CGFloat
     static func safeAreaBottomInset() -> CGFloat {
@@ -22,7 +21,6 @@ final class SafeAreaHelper {
             return 0.0
         }
     }
-    
     
     /// 하단 safeArea 크기를 가져옵니다.
     /// - Returns: CGFloat
@@ -36,18 +34,16 @@ final class SafeAreaHelper {
         }
     }
     
-    
     /// SafeArea를 포함한 스크린높이를 가져옵니다.
     /// - Returns: CGFloat
     static func getFullScreenHeight() -> CGFloat {
         return UIScreen.main.bounds.height + safeAreaBottomInset() + safeAreaTopInset()
     }
     
-    
     /// 현재 기기에 적용된  탭바의 높이를 가져옵니다.
     /// - Returns: CGFloat
     static func getBarBarHeight() -> CGFloat {
-        let defaultTabBarHeight = 56.adjustToScreenHeight
+        let defaultTabBarHeight: CGFloat = 56
         return defaultTabBarHeight + safeAreaBottomInset()
     }
 }

--- a/HongikYeolgong2/UI/Basic/SafeArea.swift
+++ b/HongikYeolgong2/UI/Basic/SafeArea.swift
@@ -19,4 +19,18 @@ final class SafeAreaHelper {
             return 0.0
         }
     }
+    
+    static func safeAreaTopInset() -> CGFloat {
+        if #available(iOS 11.0, *) {
+            let window = UIApplication.shared.keyWindow
+            let bottomPadding = window?.safeAreaInsets.top
+            return bottomPadding ??  0.0
+        } else {
+            return 0.0
+        }
+    }
+    
+    static func getFullScreenHeight() -> CGFloat {
+        return UIScreen.main.bounds.height + safeAreaBottomInset() + safeAreaTopInset()
+    }
 }

--- a/HongikYeolgong2/UI/Basic/SafeArea.swift
+++ b/HongikYeolgong2/UI/Basic/SafeArea.swift
@@ -1,0 +1,22 @@
+//
+//  SafeArea.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 10/5/24.
+//
+
+import UIKit
+
+final class SafeAreaHelper {
+    private init() {}
+    
+    static func safeAreaBottomInset() -> CGFloat {
+        if #available(iOS 11.0, *) {
+            let window = UIApplication.shared.keyWindow
+            let bottomPadding = window?.safeAreaInsets.bottom
+            return bottomPadding ??  0.0
+        } else {
+            return 0.0
+        }
+    }
+}


### PR DESCRIPTION
## AS-IS
 기기별 탭바크기 및 해상도 대응
## TO-BE
 기기별 탭바크기 및 해상도 대응
## KEY-POINT
### TabView 크기 조정
기존의 탭바는 높이값이 고정으로 들어가기에 iphoneSE 같은 기종에서 탭바가 너무 크게 나타나는 문제가 발생했습니다. 문제가 발생한 원인은 safearea의 유무로 safeare값의 여부에 따라서 추가적으로 높이를 계산하도록 수정했습니다.

```swift
 static func getBarBarHeight() -> CGFloat {
        let defaultTabBarHeight: CGFloat = 56
        return defaultTabBarHeight + safeAreaBottomInset()
    }
```
기본 탭바크기에 safeArea값을 추가적으로 계산합니다. 추후에는 기본 height값을 정해주는게 아닌 내부의 요소들에 padding을 추가하는 방식도 고려해볼만한 것 같습니다.

추가적으로 각 화면의 UI들이 탭뷰의 뒤로 숨어버리는 현상이 발생했습니다. 해당 현상은 전체뷰 맨아래에 tabBarHeight만큼 패딩을 주는 방식으로 해결했습니다.

```swift
   VStack {
                Spacer()
                switch selectedTab {
                case .home:
                    HomeView()
                case .record:
                    RecordView()
                case .ranking:
                    RankingView()
                case .setting:
                    SettingView()
                }
                Spacer()
            }
            .padding(.bottom, SafeAreaHelper.getBarBarHeight())
```

### 해상도 대응
기기별 해상도를 대응하지 않는다면 기기별로 버튼과같은 요소의 높이가 짦아보이는 현상이 발생해서 스크린 사이즈에 대응해서 높이를 정해주는 메서드를 추가했습니다 해당 방식은 기존의 방식과 동일합니다.

```swift
extension Double {
    var adjustToScreenWidth: Double {
        let ratio: Double = Double(UIScreen.main.bounds.width / 375)
        return self * ratio
    }
    
    var adjustToScreenHeight: Double {
        let ratio: Double = Double(UIScreen.main.bounds.height / 812)
        return self * ratio
    }
}
```

사용예시
```swift
 View()
   .frame(width: 100.adjustToScreenWidth)
```
## SCREENSHOT (Optional)
12 mini
<img src="https://github.com/user-attachments/assets/99d95c51-8607-4bee-93cc-0e4e3b8a0e1c" width=50%/>
iphoneSE
<img src="https://github.com/user-attachments/assets/36a8dad1-face-44dd-9c12-d004ea09c96f" width=50%/>
iphone15 promax
<img src="https://github.com/user-attachments/assets/b842e9d5-221d-4969-b598-32f23fbe0e68" width=50%/>
iphone15
<img src="https://github.com/user-attachments/assets/50c3ba9a-d94f-4de9-8a0e-db44d8c0ee42" width=50%/>



