### PR TITLE
[Fix] 회원가입 -> 메인화면 진입시 크래쉬오류 수정

### DIFF
--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor.swift
@@ -110,7 +110,7 @@ final class UserDataInteractorImpl: UserDataInteractor {
                 receiveCompletion: { [weak self] completion in
                     guard let self = self else { return }
                     switch completion {
-                    case .finished:
+                    case .finished:                        
                         appState[\.appLaunchState] = .authenticated
                     case let .failure(error):
                         appState[\.appLaunchState] = .notAuthenticated

--- a/HongikYeolgong2/Presentation/Auth/OnboardingView.swift
+++ b/HongikYeolgong2/Presentation/Auth/OnboardingView.swift
@@ -19,6 +19,7 @@ struct OnboardingView: View {
             content
                 .onReceive(routingUpdate) { self.routingState = $0 }
         }
+        .navigationViewStyle(.stack)
     }
     
     // MARK: - Main Contents

--- a/HongikYeolgong2/Presentation/Auth/SignUpView.swift
+++ b/HongikYeolgong2/Presentation/Auth/SignUpView.swift
@@ -9,11 +9,16 @@ import SwiftUI
 import Combine
 
 struct SignUpView: View {
+    @Environment(\.injected.appState) var appState
     @Environment(\.injected.interactors.userDataInteractor) var userDataInetractor
-    
+    @Environment(\.presentationMode) var presentationMode
     @State private var signupData = SignupData()
     @State private var isSubmitButtonAvailable = false
     @State private var isCheckButtonAvailable = false
+    
+    init() {
+        UINavigationBar.setAnimationsEnabled(false)
+    }
     
     var body: some View {
         content

--- a/HongikYeolgong2/Presentation/Home/HomeView.swift
+++ b/HongikYeolgong2/Presentation/Home/HomeView.swift
@@ -80,9 +80,11 @@ struct HomeView: View {
         }
         .padding(.horizontal, 32.adjustToScreenWidth)
         .modifier(GradientBackground())
-        .onAppear { permissions.request(permission: .localNotifications) }
-        .onAppear { weeklyStudyInteractor.getWeekyStudy(studyRecords: $studyRecords) }
-        .onAppear { weeklyStudyInteractor.getWiseSaying(wiseSaying: $wiseSaying) }
+        .onAppear {
+            permissions.request(permission: .localNotifications)
+            weeklyStudyInteractor.getWeekyStudy(studyRecords: $studyRecords)
+            weeklyStudyInteractor.getWiseSaying(wiseSaying: $wiseSaying)
+        }
         .onReceive(studySessionUpdated) { studySession = $0 }
     }
 }

--- a/HongikYeolgong2/Presentation/Root/InitialView.swift
+++ b/HongikYeolgong2/Presentation/Root/InitialView.swift
@@ -12,7 +12,7 @@ struct InitialView: View {
     @Environment(\.injected) var injected: DIContainer
     
     @State private var appLaunchState: AppState.AppLaunchState = .checkAuthentication
-    
+    @State private var curentTab: Tab = .home
     var body: some View {
         NavigationView {
             switch appLaunchState {

--- a/HongikYeolgong2/Presentation/Root/InitialView.swift
+++ b/HongikYeolgong2/Presentation/Root/InitialView.swift
@@ -14,23 +14,20 @@ struct InitialView: View {
     @State private var appLaunchState: AppState.AppLaunchState = .checkAuthentication
     
     var body: some View {
-        Group {
-            content
-                .onReceive(isAppLaunchStateUpdated) { appLaunchState = $0 }
+        NavigationView {
+            switch appLaunchState {
+            case .notAuthenticated:
+                OnboardingView()                    
+            case .authenticated:
+                MainTabView()
+            case .checkAuthentication:
+                SplashView()
+                    .ignoresSafeArea(.all)
+                    .onAppear(perform: appLaunchCompleted)
+            }
         }
-    }
-    
-    @ViewBuilder private var content: some View {
-        switch appLaunchState {
-        case .notAuthenticated:
-            OnboardingView()
-        case .authenticated:
-            MainTabView()
-        case .checkAuthentication:
-            SplashView()
-                .ignoresSafeArea(.all)
-                .onAppear(perform: appLaunchCompleted)
-        }
+        .navigationViewStyle(.stack)
+        .onReceive(isAppLaunchStateUpdated) { appLaunchState = $0 }
     }
 }
 

--- a/HongikYeolgong2/Presentation/Root/InitialView.swift
+++ b/HongikYeolgong2/Presentation/Root/InitialView.swift
@@ -12,7 +12,7 @@ struct InitialView: View {
     @Environment(\.injected) var injected: DIContainer
     
     @State private var appLaunchState: AppState.AppLaunchState = .checkAuthentication
-    @State private var curentTab: Tab = .home
+    
     var body: some View {
         NavigationView {
             switch appLaunchState {

--- a/HongikYeolgong2/Presentation/Root/MainTabView.swift
+++ b/HongikYeolgong2/Presentation/Root/MainTabView.swift
@@ -55,7 +55,7 @@ enum Tab: CaseIterable {
 
 struct MainTabView: View {
     @State private var selectedTab: Tab = .home
-
+    
     var body: some View {
         ZStack(alignment: .bottom) {
             Color.dark.ignoresSafeArea(.all)
@@ -64,7 +64,7 @@ struct MainTabView: View {
                 Spacer()
                 switch selectedTab {
                 case .home:
-                    HomeView()
+                    HomeView()                    
                 case .record:
                     RecordView()
                 case .ranking:

--- a/HongikYeolgong2/Presentation/Root/MainTabView.swift
+++ b/HongikYeolgong2/Presentation/Root/MainTabView.swift
@@ -15,75 +15,59 @@ enum Tab: CaseIterable {
     
     var title: String {
         switch self {
-        case .home:
-            "홈"
-        case .record:
-            "기록"
-        case .ranking:
-            "랭킹"
-        case .setting:
-            "설정"
+        case .home: "홈"
+        case .record: "기록"
+        case .ranking: "랭킹"
+        case .setting: "설정"
         }
     }
     
     var iconName: String {
         switch self {
-        case .home:
-            "home"
-        case .record:
-            "calendar"
-        case .ranking:
-            "ranking"
-        case .setting:
-            "setting"
+        case .home: "home"
+        case .record: "calendar"
+        case .ranking: "ranking"
+        case .setting: "setting"
         }
     }
     
     var iconNameSelected: String {
         switch self {
-        case .home:
-            "homeSelected"
-        case .record:
-            "calendarSelected"
-        case .ranking:
-            "rankingSelected"
-        case .setting:
-            "settingSelected"
+        case .home: "homeSelected"
+        case .record: "calendarSelected"
+        case .ranking: "rankingSelected"
+        case .setting: "settingSelected"
         }
     }
 }
 
 struct MainTabView: View {
-    @State private var selectedTab: Tab = .home
+    @State private var currentTab: Tab = .home
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            Color.dark.ignoresSafeArea(.all)
+        TabView(selection: $currentTab,
+                content:  {
+            HomeView()
+                .tag(Tab.home)
             
-            VStack(spacing: 0) {
-                Spacer()
-                switch selectedTab {
-                case .home:
-                    HomeView()                    
-                case .record:
-                    RecordView()
-                case .ranking:
-                    RankingView()
-                case .setting:
-                    SettingView()
-                }
-                Spacer()
-            }
-            .padding(.bottom, SafeAreaHelper.getTabBarHeight())
+            RecordView()
+                .tag(Tab.record)
             
-            TabBarView(selectedTab: $selectedTab)
+            RankingView()
+                .tag(Tab.ranking)
+            
+            SettingView()
+                .tag(Tab.setting)
+        })
+        .overlay(alignment: .bottom) {
+            TabBarView(currentTab: $currentTab)
         }
-        .edgesIgnoringSafeArea(.bottom)        
+        .edgesIgnoringSafeArea(.bottom)
     }
 }
 
 struct TabBarView: View {
-    @Binding var selectedTab: Tab
+    @Binding var currentTab: Tab
     
     var body: some View {
         VStack(spacing: 0) {
@@ -92,17 +76,17 @@ struct TabBarView: View {
                 
                 ForEach(Tab.allCases, id: \.hashValue) { tab in
                     VStack(spacing: 5.adjustToScreenHeight) {
-                        Image(tab == selectedTab ? tab.iconNameSelected : tab.iconName, bundle: nil)
+                        Image(tab == currentTab ? tab.iconNameSelected : tab.iconName, bundle: nil)
                         
                         Text(tab.title)
                             .font(.pretendard(size: 12, weight: .regular))
-                            .foregroundStyle(tab == selectedTab ? .gray100 : .gray300)
+                            .foregroundStyle(tab == currentTab ? .gray100 : .gray300)
                             .frame(height: 18.adjustToScreenHeight)
                     }
                     .frame(maxWidth: .infinity)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        selectedTab = tab
+                        currentTab = tab
                     }
                     
                     Spacer()
@@ -122,3 +106,4 @@ struct TabBarView: View {
 #Preview {
     MainTabView()
 }
+

--- a/HongikYeolgong2/Util/Extensions/URLRequest+.swift
+++ b/HongikYeolgong2/Util/Extensions/URLRequest+.swift
@@ -11,7 +11,7 @@ import Foundation
 extension URLRequest {
     init(_ url: URL) {
         self.init(url: url)
-        let accessToken = KeyChainManager.readItem(key: .accessToken) ?? ""               
+        let accessToken = KeyChainManager.readItem(key: .accessToken) ?? ""          
         self.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
     }
 }


### PR DESCRIPTION
## AS-IS
회원가입 -> 메인화면 진입시 크래쉬 오류 수정
## TO-BE
회원가입 -> 메인화면 진입시 크래쉬 오류 수정
## KEY-POINT
NavigationView 사용시 스택을 제거하지 않고 화면 전환시 나타날 수 있는 오류로 확인 되었습니다. 
- 앱전체에 NavigationView를 추가하여 Onboarding, Splash, MainTab을 관리하는 RootViewController를 추가했습니다.
- 회원가입 -> MainTab 진입시 애니메이션을 강제로 비활성화 했습니다.

**+ 기존 TabView 사용방식 변경**

기존의 커스텀탭뷰 사용시 탭이 변경될때마다 View 자체가 다시 생성되는 문제를 확인했습니다. 
1. ZStack으로 모든뷰를 로드한 상태로 선택한 탭에따라 분기처리
2. 기본 TabView를 사용한 커스텀탭뷰 방식

1번 방법으로 구현에는 문제가 없지만 Lazyload를 직접 구현해야 하기때문에 간단한 2번 방법으로 변경하였습니다.

## SCREENSHOT (Optional)
