### PR TITLE
[Feature] 애플로그인 회원탈퇴 정책 반영

### DIFF
--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		47C8154B2CE231810017EA24 /* SwiftJWT in Frameworks */ = {isa = PBXBuildFile; productRef = 47C8154A2CE231810017EA24 /* SwiftJWT */; };
 		47C815532CE257950017EA24 /* AuthKey_843UNB7W58.p8 in Resources */ = {isa = PBXBuildFile; fileRef = 47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */; };
 		47C815552CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815542CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift */; };
+		47C815582CE27E140017EA24 /* OnboardingPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815572CE27E140017EA24 /* OnboardingPageView.swift */; };
+		47C8155A2CE27EB00017EA24 /* AppleLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815592CE27EB00017EA24 /* AppleLoginButton.swift */; };
 		47CA17252CC9336100CBB251 /* StudyPeriodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17242CC9336100CBB251 /* StudyPeriodView.swift */; };
 		47CA17272CC9340800CBB251 /* StudyTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17262CC9340800CBB251 /* StudyTimerView.swift */; };
 		47D5EDCD2CCBCB6D00ACA469 /* ImageBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */; };
@@ -290,6 +292,8 @@
 		47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTokenRequestDTO.swift; sourceTree = "<group>"; };
 		47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AuthKey_843UNB7W58.p8; sourceTree = "<group>"; };
 		47C815542CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASRevokeTokenRequestDTO.swift; sourceTree = "<group>"; };
+		47C815572CE27E140017EA24 /* OnboardingPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageView.swift; sourceTree = "<group>"; };
+		47C815592CE27EB00017EA24 /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
 		47CA17242CC9336100CBB251 /* StudyPeriodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyPeriodView.swift; sourceTree = "<group>"; };
 		47CA17262CC9340800CBB251 /* StudyTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyTimerView.swift; sourceTree = "<group>"; };
 		47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackground.swift; sourceTree = "<group>"; };
@@ -773,6 +777,7 @@
 		47A5406E2CD0B8AB00DC40D0 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				47C815562CE27E050017EA24 /* Component */,
 				47A1477F2CA15A4E00A91F66 /* OnboardingView.swift */,
 			);
 			path = Onboarding;
@@ -861,6 +866,15 @@
 				471940C62CAFCA6200426D30 /* Modifier */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		47C815562CE27E050017EA24 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				47C815572CE27E140017EA24 /* OnboardingPageView.swift */,
+				47C815592CE27EB00017EA24 /* AppleLoginButton.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		47D5EDC52CCB66BD00ACA469 /* StudyTimer */ = {
@@ -1183,6 +1197,7 @@
 				47BACCF72CA164BA00295DAC /* Font+.swift in Sources */,
 				4786A1102CCA351A008635A4 /* WeeklyStudySessionDTO.swift in Sources */,
 				5E847A742CDBD52E0034C2A7 /* CalendarDataInteractor.swift in Sources */,
+				47C8155A2CE27EB00017EA24 /* AppleLoginButton.swift in Sources */,
 				47C815482CE227E50017EA24 /* ASTokenRequestDTO.swift in Sources */,
 				470722FA2CBC0A870046469F /* Constants.swift in Sources */,
 				478F84492CD359260097CAA1 /* WeeklyRanking.swift in Sources */,
@@ -1232,6 +1247,7 @@
 				470723092CBC198E0046469F /* AuthRepository.swift in Sources */,
 				47F4F6972CC88FBB00543D24 /* SignUpRequestDTO.swift in Sources */,
 				478004422CCA924200FFAF00 /* StudySessionMapper.swift in Sources */,
+				47C815582CE27E140017EA24 /* OnboardingPageView.swift in Sources */,
 				478F84372CD30A8F0097CAA1 /* IOSBackground.swift in Sources */,
 				47A1474E2CA144EC00A91F66 /* StudyRoomUsage+Mock.swift in Sources */,
 				4774C7BB2CDF632300CDD479 /* WithdrawResponseDTO.swift in Sources */,

--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -113,6 +113,10 @@
 		47C815382CE21E640017EA24 /* ASAuthEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815372CE21E640017EA24 /* ASAuthEndpoint.swift */; };
 		47C815412CE221060017EA24 /* SocialLoginRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815402CE221060017EA24 /* SocialLoginRepositoryImpl.swift */; };
 		47C815432CE2211D0017EA24 /* SocialLoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815422CE2211D0017EA24 /* SocialLoginRepository.swift */; };
+		47C815462CE223DA0017EA24 /* ASTokenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815452CE223DA0017EA24 /* ASTokenResponseDTO.swift */; };
+		47C815482CE227E50017EA24 /* ASTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */; };
+		47C8154B2CE231810017EA24 /* SwiftJWT in Frameworks */ = {isa = PBXBuildFile; productRef = 47C8154A2CE231810017EA24 /* SwiftJWT */; };
+		47C815532CE257950017EA24 /* AuthKey_843UNB7W58.p8 in Resources */ = {isa = PBXBuildFile; fileRef = 47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */; };
 		47CA17252CC9336100CBB251 /* StudyPeriodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17242CC9336100CBB251 /* StudyPeriodView.swift */; };
 		47CA17272CC9340800CBB251 /* StudyTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17262CC9340800CBB251 /* StudyTimerView.swift */; };
 		47D5EDCD2CCBCB6D00ACA469 /* ImageBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */; };
@@ -281,6 +285,9 @@
 		47C815372CE21E640017EA24 /* ASAuthEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthEndpoint.swift; sourceTree = "<group>"; };
 		47C815402CE221060017EA24 /* SocialLoginRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginRepositoryImpl.swift; sourceTree = "<group>"; };
 		47C815422CE2211D0017EA24 /* SocialLoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginRepository.swift; sourceTree = "<group>"; };
+		47C815452CE223DA0017EA24 /* ASTokenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTokenResponseDTO.swift; sourceTree = "<group>"; };
+		47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTokenRequestDTO.swift; sourceTree = "<group>"; };
+		47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AuthKey_843UNB7W58.p8; sourceTree = "<group>"; };
 		47CA17242CC9336100CBB251 /* StudyPeriodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyPeriodView.swift; sourceTree = "<group>"; };
 		47CA17262CC9340800CBB251 /* StudyTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyTimerView.swift; sourceTree = "<group>"; };
 		47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackground.swift; sourceTree = "<group>"; };
@@ -323,6 +330,7 @@
 				47F71B592CDC68BC0044DEC5 /* FirebaseFirestoreCombine-Community in Frameworks */,
 				47F71B532CDC68BC0044DEC5 /* FirebaseAuthCombine-Community in Frameworks */,
 				47F71B632CDC813A0044DEC5 /* FirebaseFunctionsCombine-Community in Frameworks */,
+				47C8154B2CE231810017EA24 /* SwiftJWT in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -779,6 +787,7 @@
 		47B1D49F2C9CB1740071B62B = {
 			isa = PBXGroup;
 			children = (
+				47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */,
 				98B5F0092CDB362C007CF5FA /* Secrets-dev.xcconfig */,
 				479821D32CA24CFF002357EB /* .swiftlint.yml */,
 				47B1D4AA2C9CB1740071B62B /* HongikYeolgong2 */,
@@ -903,6 +912,8 @@
 				47F4F6982CC89A6900543D24 /* SignUpResponseDTO.swift */,
 				470483A92CDB532A00C381ED /* TokenValidResponseDTO.swift */,
 				4774C7BA2CDF632300CDD479 /* WithdrawResponseDTO.swift */,
+				47C815452CE223DA0017EA24 /* ASTokenResponseDTO.swift */,
+				47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -979,6 +990,7 @@
 				47F71B5E2CDC813A0044DEC5 /* FirebaseDatabase */,
 				47F71B602CDC813A0044DEC5 /* FirebaseFunctions */,
 				47F71B622CDC813A0044DEC5 /* FirebaseFunctionsCombine-Community */,
+				47C8154A2CE231810017EA24 /* SwiftJWT */,
 			);
 			productName = HongikYeolgong2;
 			productReference = 47B1D4A82C9CB1740071B62B /* HongikYeolgong2.app */;
@@ -1054,6 +1066,7 @@
 			mainGroup = 47B1D49F2C9CB1740071B62B;
 			packageReferences = (
 				47F71B4F2CDC68BC0044DEC5 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				47C815492CE231810017EA24 /* XCRemoteSwiftPackageReference "Swift-JWT" */,
 			);
 			productRefGroup = 47B1D4A92C9CB1740071B62B /* Products */;
 			projectDirPath = "";
@@ -1082,6 +1095,7 @@
 				47A147652CA147A600A91F66 /* Pretendard-ExtraBold.otf in Resources */,
 				47B1D4B32C9CB1760071B62B /* Preview Assets.xcassets in Resources */,
 				47A1476D2CA147A600A91F66 /* SUITE-ExtraBold.otf in Resources */,
+				47C815532CE257950017EA24 /* AuthKey_843UNB7W58.p8 in Resources */,
 				47A1476F2CA147A600A91F66 /* SUITE-Light.otf in Resources */,
 				47A147722CA147A600A91F66 /* SUITE-SemiBold.otf in Resources */,
 				47B1D4B02C9CB1760071B62B /* Assets.xcassets in Resources */,
@@ -1166,6 +1180,7 @@
 				47BACCF72CA164BA00295DAC /* Font+.swift in Sources */,
 				4786A1102CCA351A008635A4 /* WeeklyStudySessionDTO.swift in Sources */,
 				5E847A742CDBD52E0034C2A7 /* CalendarDataInteractor.swift in Sources */,
+				47C815482CE227E50017EA24 /* ASTokenRequestDTO.swift in Sources */,
 				470722FA2CBC0A870046469F /* Constants.swift in Sources */,
 				478F84492CD359260097CAA1 /* WeeklyRanking.swift in Sources */,
 				4786A0EC2CC9E2BC008635A4 /* UserPermissionsInteractor.swift in Sources */,
@@ -1210,6 +1225,7 @@
 				47F71B5D2CDC77C60044DEC5 /* UserDataInteractor+Migration.swift in Sources */,
 				4763FFB52CB90EBD00990336 /* InitialView.swift in Sources */,
 				47E250712CCF274400267897 /* WeeklyStudyInteractor.swift in Sources */,
+				47C815462CE223DA0017EA24 /* ASTokenResponseDTO.swift in Sources */,
 				470723092CBC198E0046469F /* AuthRepository.swift in Sources */,
 				47F4F6972CC88FBB00543D24 /* SignUpRequestDTO.swift in Sources */,
 				478004422CCA924200FFAF00 /* StudySessionMapper.swift in Sources */,
@@ -1617,6 +1633,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		47C815492CE231810017EA24 /* XCRemoteSwiftPackageReference "Swift-JWT" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Kitura/Swift-JWT.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.1;
+			};
+		};
 		47F71B4F2CDC68BC0044DEC5 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -1628,6 +1652,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		47C8154A2CE231810017EA24 /* SwiftJWT */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 47C815492CE231810017EA24 /* XCRemoteSwiftPackageReference "Swift-JWT" */;
+			productName = SwiftJWT;
+		};
 		47F71B502CDC68BC0044DEC5 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 47F71B4F2CDC68BC0044DEC5 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		47C815482CE227E50017EA24 /* ASTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */; };
 		47C8154B2CE231810017EA24 /* SwiftJWT in Frameworks */ = {isa = PBXBuildFile; productRef = 47C8154A2CE231810017EA24 /* SwiftJWT */; };
 		47C815532CE257950017EA24 /* AuthKey_843UNB7W58.p8 in Resources */ = {isa = PBXBuildFile; fileRef = 47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */; };
+		47C815552CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815542CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift */; };
 		47CA17252CC9336100CBB251 /* StudyPeriodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17242CC9336100CBB251 /* StudyPeriodView.swift */; };
 		47CA17272CC9340800CBB251 /* StudyTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17262CC9340800CBB251 /* StudyTimerView.swift */; };
 		47D5EDCD2CCBCB6D00ACA469 /* ImageBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */; };
@@ -288,6 +289,7 @@
 		47C815452CE223DA0017EA24 /* ASTokenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTokenResponseDTO.swift; sourceTree = "<group>"; };
 		47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASTokenRequestDTO.swift; sourceTree = "<group>"; };
 		47C815522CE257950017EA24 /* AuthKey_843UNB7W58.p8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AuthKey_843UNB7W58.p8; sourceTree = "<group>"; };
+		47C815542CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASRevokeTokenRequestDTO.swift; sourceTree = "<group>"; };
 		47CA17242CC9336100CBB251 /* StudyPeriodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyPeriodView.swift; sourceTree = "<group>"; };
 		47CA17262CC9340800CBB251 /* StudyTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyTimerView.swift; sourceTree = "<group>"; };
 		47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackground.swift; sourceTree = "<group>"; };
@@ -914,6 +916,7 @@
 				4774C7BA2CDF632300CDD479 /* WithdrawResponseDTO.swift */,
 				47C815452CE223DA0017EA24 /* ASTokenResponseDTO.swift */,
 				47C815472CE227E50017EA24 /* ASTokenRequestDTO.swift */,
+				47C815542CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1255,6 +1258,7 @@
 				473E8EB22CCE5267000F102C /* SystemOverlay.swift in Sources */,
 				475B86DF2CA1AF1E000534B2 /* RecordView.swift in Sources */,
 				98F9D8462CDA2E6D00DE12BB /* RecordCell.swift in Sources */,
+				47C815552CE26EE40017EA24 /* ASRevokeTokenRequestDTO.swift in Sources */,
 				47A147792CA158E800A91F66 /* MainTabView.swift in Sources */,
 				47F79B302CCCB7FC00DD0899 /* TimePicker.swift in Sources */,
 				478FBCA32CD13A1E00256012 /* UserInfo.swift in Sources */,

--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -110,6 +110,9 @@
 		47BACCF72CA164BA00295DAC /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BACCF62CA164BA00295DAC /* Font+.swift */; };
 		47BE30E32CC813BB0015D973 /* KeyChainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BE30E22CC813BB0015D973 /* KeyChainManager.swift */; };
 		47BE30E52CC81A9E0015D973 /* URLRequest+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BE30E42CC81A9E0015D973 /* URLRequest+.swift */; };
+		47C815382CE21E640017EA24 /* ASAuthEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815372CE21E640017EA24 /* ASAuthEndpoint.swift */; };
+		47C815412CE221060017EA24 /* SocialLoginRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815402CE221060017EA24 /* SocialLoginRepositoryImpl.swift */; };
+		47C815432CE2211D0017EA24 /* SocialLoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C815422CE2211D0017EA24 /* SocialLoginRepository.swift */; };
 		47CA17252CC9336100CBB251 /* StudyPeriodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17242CC9336100CBB251 /* StudyPeriodView.swift */; };
 		47CA17272CC9340800CBB251 /* StudyTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CA17262CC9340800CBB251 /* StudyTimerView.swift */; };
 		47D5EDCD2CCBCB6D00ACA469 /* ImageBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */; };
@@ -275,6 +278,9 @@
 		47BACCF62CA164BA00295DAC /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
 		47BE30E22CC813BB0015D973 /* KeyChainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainManager.swift; sourceTree = "<group>"; };
 		47BE30E42CC81A9E0015D973 /* URLRequest+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+.swift"; sourceTree = "<group>"; };
+		47C815372CE21E640017EA24 /* ASAuthEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthEndpoint.swift; sourceTree = "<group>"; };
+		47C815402CE221060017EA24 /* SocialLoginRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginRepositoryImpl.swift; sourceTree = "<group>"; };
+		47C815422CE2211D0017EA24 /* SocialLoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginRepository.swift; sourceTree = "<group>"; };
 		47CA17242CC9336100CBB251 /* StudyPeriodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyPeriodView.swift; sourceTree = "<group>"; };
 		47CA17262CC9340800CBB251 /* StudyTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyTimerView.swift; sourceTree = "<group>"; };
 		47D5EDCC2CCBCB6D00ACA469 /* ImageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackground.swift; sourceTree = "<group>"; };
@@ -353,6 +359,7 @@
 				47F635012CC3E98D0034EAA9 /* UserEndpoint.swift */,
 				4786A1062CCA33DF008635A4 /* WeeklyEndpoint.swift */,
 				470483A72CDB50FA00C381ED /* TokenEndpoint.swift */,
+				47C815372CE21E640017EA24 /* ASAuthEndpoint.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -371,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				4707230A2CBC19C10046469F /* AuthRepositoryImpl.swift */,
+				47C815402CE221060017EA24 /* SocialLoginRepositoryImpl.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -685,6 +693,7 @@
 				470723082CBC198E0046469F /* AuthRepository.swift */,
 				4786A1082CCA346F008635A4 /* StudySessionRepository.swift */,
 				478F843D2CD326E90097CAA1 /* WeeklyRepository.swift */,
+				47C815422CE2211D0017EA24 /* SocialLoginRepository.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -1134,6 +1143,7 @@
 				472319ED2CD1FC32009BA019 /* UIApplication+.swift in Sources */,
 				4763FFB12CB90C1500990336 /* DependencyInjector.swift in Sources */,
 				47F79B2E2CCCB7AA00DD0899 /* TimePickerView.swift in Sources */,
+				47C815432CE2211D0017EA24 /* SocialLoginRepository.swift in Sources */,
 				476D26092CDDF2B6002FEF5C /* CalendarCountAllResponseDTO.swift in Sources */,
 				478F84392CD3176E0097CAA1 /* RankingDataInteractor.swift in Sources */,
 				475B86E12CA1AF31000534B2 /* RankingView.swift in Sources */,
@@ -1147,6 +1157,7 @@
 				478F84442CD350850097CAA1 /* WeeklyRankingResponseDTO.swift in Sources */,
 				473E8EBC2CCEBEF3000F102C /* ModalView.swift in Sources */,
 				473E8EB62CCE6A02000F102C /* Date+.swift in Sources */,
+				47C815412CE221060017EA24 /* SocialLoginRepositoryImpl.swift in Sources */,
 				470483A82CDB50FA00C381ED /* TokenEndpoint.swift in Sources */,
 				471940CB2CAFD9B700426D30 /* RankingCell.swift in Sources */,
 				473671A72CB1404E00527896 /* Ratio.swift in Sources */,
@@ -1170,6 +1181,7 @@
 				478F84412CD33F620097CAA1 /* WeekFieldResponseDTO.swift in Sources */,
 				473E8EBA2CCEA702000F102C /* StudySessionResponseDTO.swift in Sources */,
 				4752A27D2CB96EB00073B784 /* CancleBag.swift in Sources */,
+				47C815382CE21E640017EA24 /* ASAuthEndpoint.swift in Sources */,
 				47A9DCC32CE0DB97001DE76D /* WebView.swift in Sources */,
 				4736719F2CB120A600527896 /* WeeklyStudyView.swift in Sources */,
 				4780044C2CCAAD4F00FFAF00 /* WeekDay.swift in Sources */,

--- a/HongikYeolgong2.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HongikYeolgong2.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -118,5 +119,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/HongikYeolgong2.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HongikYeolgong2.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
+  "originHash" : "37f87f153a7df0e69f7682478910cd31cbff8c536dc79a044414e38ba896c24f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -17,6 +17,33 @@
       "state" : {
         "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
         "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "bluecryptor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/BlueCryptor.git",
+      "state" : {
+        "revision" : "cec97c24b111351e70e448972a7d3fe68a756d6d",
+        "version" : "2.0.2"
+      }
+    },
+    {
+      "identity" : "blueecc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/BlueECC.git",
+      "state" : {
+        "revision" : "1485268a54f8135435a825a855e733f026fa6cc8",
+        "version" : "1.2.201"
+      }
+    },
+    {
+      "identity" : "bluersa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/BlueRSA.git",
+      "state" : {
+        "revision" : "440f78db26d8bb073f29590f1c7bd31004da09ae",
+        "version" : "1.0.201"
       }
     },
     {
@@ -83,12 +110,30 @@
       }
     },
     {
+      "identity" : "kituracontracts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/KituraContracts.git",
+      "state" : {
+        "revision" : "6edf7ac3dd2b3a2c61284778d430bbad7d8a6f23",
+        "version" : "2.0.1"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "loggerapi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/LoggerAPI.git",
+      "state" : {
+        "revision" : "4e6b45e850ffa275e8e26a24c6454fd709d5b6ac",
+        "version" : "2.0.0"
       }
     },
     {
@@ -107,6 +152,24 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-jwt",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/Swift-JWT.git",
+      "state" : {
+        "revision" : "f68ec28fbd90a651597e9e825ea7f315f8d52a1f",
+        "version" : "4.0.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {

--- a/HongikYeolgong2/Core/AppEnviroment.swift
+++ b/HongikYeolgong2/Core/AppEnviroment.swift
@@ -64,7 +64,8 @@ extension AppEnviroment {
             userDataInteractor: UserDataMigrationInteractor(
                 appState: appState,
                 authRepository: remoteRepository.authRepository,
-                authService: services.appleAuthService
+                socialLoginRepository: SocialLoginRepositoryImpl(),
+                appleLoginService: services.appleAuthService
             ),
             studyTimeInteractor: StudyTimeInteractorImpl(
                 studySessionRepository: remoteRepository.studySessionRepository

--- a/HongikYeolgong2/Core/AppEnviroment.swift
+++ b/HongikYeolgong2/Core/AppEnviroment.swift
@@ -93,7 +93,7 @@ extension AppEnviroment {
     /// 앱의 서비스를 구성하는 컨테이너를 반환합니다.
     /// - Returns: 앱의 서비스를 구성하는 컨테이너
     static func configuredServices() -> DIContainer.Services {
-        .init(appleAuthService: AuthenticationServiceImpl())
+        .init(appleAuthService: AppleLoginManager())
     }
 }
 
@@ -105,6 +105,6 @@ extension DIContainer {
     }
     
     struct Services {
-        let appleAuthService: AppleLoginManager
+        let appleAuthService: AppleLoginService
     }
 }

--- a/HongikYeolgong2/Data/DTO/Auth/ASRevokeTokenRequestDTO.swift
+++ b/HongikYeolgong2/Data/DTO/Auth/ASRevokeTokenRequestDTO.swift
@@ -1,0 +1,15 @@
+//
+//  ASRevokeTokenRequestDTO.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/12/24.
+//
+
+import Foundation
+
+struct ASRevokeTokenRequestDTO {
+    let client_id: String
+    let client_secret: String
+    let token: String
+    let token_type_hint: String
+}

--- a/HongikYeolgong2/Data/DTO/Auth/ASTokenRequestDTO.swift
+++ b/HongikYeolgong2/Data/DTO/Auth/ASTokenRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  ASTokenRequestDTO.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/11/24.
+//
+
+import Foundation
+
+struct ASTokenRequestDTO: Encodable {
+    let client_id: String
+    let client_secret: String
+    let grant_type: String
+    let code: String
+    var refresh_token: String?
+    var redirect_uri: String?
+}

--- a/HongikYeolgong2/Data/DTO/Auth/ASTokenResponseDTO.swift
+++ b/HongikYeolgong2/Data/DTO/Auth/ASTokenResponseDTO.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct ASTokenResponseDTO: Decodable {
-    let access_token: String
-    let expires_in: Int
-    let id_token: String
-    let refresh_token: String
-    let token_type: String        
+    let accessToken: String
+    let expiresIn: Int
+    let idToken: String
+    let refreshToken: String
+    let tokenType: String
 }
 

--- a/HongikYeolgong2/Data/DTO/Auth/ASTokenResponseDTO.swift
+++ b/HongikYeolgong2/Data/DTO/Auth/ASTokenResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  ASTokenResponseDTO.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/11/24.
+//
+
+import Foundation
+
+struct ASTokenResponseDTO: Decodable {
+    let access_token: String
+    let expires_in: Int
+    let id_token: String
+    let refresh_token: String
+    let token_type: String        
+}
+

--- a/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
+++ b/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
@@ -12,12 +12,10 @@ final class SocialLoginRepositoryImpl: SocialLoginRepository {
         return Future<ASTokenResponseDTO, NetworkError> { promise in
             Task {
                 do {
-                    let response: BaseResponse<ASTokenResponseDTO> = try await NetworkService.shared.request(endpoint: ASAuthEndpoint.requestToken(asTokenRequestDto))
-                    print(response.data)
-                    promise(.success(response.data))
+                    let response: ASTokenResponseDTO = try await NetworkService.shared.request(endpoint: ASAuthEndpoint.requestToken(asTokenRequestDto))
+                    promise(.success(response))
                 }
-                catch let error as NetworkError {
-                    print(error.message)
+                catch let error as NetworkError {                    
                     promise(.failure(error))
                 }
             }

--- a/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
+++ b/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
@@ -8,6 +8,20 @@
 import Combine
 
 final class SocialLoginRepositoryImpl: SocialLoginRepository {
+    func requestASTokenRevoke(asRevokeTokenRequestDto: ASRevokeTokenRequestDTO) -> AnyPublisher<Void, NetworkError> {
+        return Future<Void, NetworkError> { promise in
+            Task {
+                do {
+                    let _ = try await NetworkService.shared.plainRequest(endpoint: ASAuthEndpoint.requestRevoke(asRevokeTokenRequestDto))
+                    promise(.success(()))
+                }
+                catch let error as NetworkError {
+                    promise(.failure(error))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
     func requestASToken(asTokenRequestDto: ASTokenRequestDTO) -> AnyPublisher<ASTokenResponseDTO, NetworkError> {
         return Future<ASTokenResponseDTO, NetworkError> { promise in
             Task {
@@ -15,7 +29,7 @@ final class SocialLoginRepositoryImpl: SocialLoginRepository {
                     let response: ASTokenResponseDTO = try await NetworkService.shared.request(endpoint: ASAuthEndpoint.requestToken(asTokenRequestDto))
                     promise(.success(response))
                 }
-                catch let error as NetworkError {                    
+                catch let error as NetworkError {
                     promise(.failure(error))
                 }
             }

--- a/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
+++ b/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
@@ -1,0 +1,20 @@
+//
+//  SocialLoginRepository.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/11/24.
+//
+
+import Combine
+
+final class SocialLoginRepositoryImpl {
+    func requestASToken() {
+        Task {
+            do {
+                
+            } catch {
+                
+            }
+        }
+    }
+}

--- a/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
+++ b/HongikYeolgong2/Data/Repositories/Auth/SocialLoginRepositoryImpl.swift
@@ -7,14 +7,20 @@
 
 import Combine
 
-final class SocialLoginRepositoryImpl {
-    func requestASToken() {
-        Task {
-            do {
-                
-            } catch {
-                
+final class SocialLoginRepositoryImpl: SocialLoginRepository {
+    func requestASToken(asTokenRequestDto: ASTokenRequestDTO) -> AnyPublisher<ASTokenResponseDTO, NetworkError> {
+        return Future<ASTokenResponseDTO, NetworkError> { promise in
+            Task {
+                do {
+                    let response: BaseResponse<ASTokenResponseDTO> = try await NetworkService.shared.request(endpoint: ASAuthEndpoint.requestToken(asTokenRequestDto))
+                    print(response.data)
+                    promise(.success(response.data))
+                }
+                catch let error as NetworkError {
+                    print(error.message)
+                    promise(.failure(error))
+                }
             }
-        }
+        }.eraseToAnyPublisher()
     }
 }

--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
@@ -185,28 +185,29 @@ final class UserDataMigrationInteractor: UserDataInteractor {
     }
     
     func withdraw() {
-        authService.performExistingAccountSetupFlows()
+        authService.performExistingAccountSetupFlows()           
             .sink { _ in
                 
-            } receiveValue: { appleIDcredential in
-                guard let appleIDcredential = appleIDcredential else { return }                
+            } receiveValue: { _ in
+                
             }
             .store(in: cancleBag)
-
-//        authRepository
-//            .withdraw()
-//            .sink(receiveCompletion: { _ in }) { [weak self] in
-//                guard let self = self else { return }
-//                appState.bulkUpdate { appState in
-//                    appState.userSession = .unauthenticated
-//                    appState.userData = .init()
-//                    appState.permissions = .init()
-//                    appState.studySession = .init()
-//                    appState.system = .init()
-//                }
-//                KeyChainManager.deleteItem(key: .accessToken)
-//            }
-//            .store(in: cancleBag)
+        
+        
+        //        authRepository
+        //            .withdraw()
+        //            .sink(receiveCompletion: { _ in }) { [weak self] in
+        //                guard let self = self else { return }
+        //                appState.bulkUpdate { appState in
+        //                    appState.userSession = .unauthenticated
+        //                    appState.userData = .init()
+        //                    appState.permissions = .init()
+        //                    appState.studySession = .init()
+        //                    appState.system = .init()
+        //                }
+        //                KeyChainManager.deleteItem(key: .accessToken)
+        //            }
+        //            .store(in: cancleBag)
     }
 }
 

--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
@@ -33,7 +33,9 @@ final class UserDataMigrationInteractor: UserDataInteractor {
     ///  애플로그인을 요청합니다.
     /// - Parameter authorization: ASAuthorization
     func requestAppleLogin(_ authorization: ASAuthorization) {
-        guard let (email, idToken) = authService.requestAppleLogin(authorization) else {
+        guard let appleIDCredential = authService.requestAppleLogin(authorization),
+              let idTokenData = appleIDCredential.identityToken,
+              let idToken = String(data: idTokenData, encoding: .utf8) else {
             return
         }
         

--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
@@ -188,6 +188,7 @@ final class UserDataMigrationInteractor: UserDataInteractor {
             .store(in: cancleBag)
     }
     
+    /// 회원 탈퇴
     func withdraw() {
         let clientSecret = makeJWT()
         

--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor+Migration.swift
@@ -188,7 +188,7 @@ final class UserDataMigrationInteractor: UserDataInteractor {
             .store(in: cancleBag)
     }
     
-    func withdraw() {        
+    func withdraw() {
         appleLoginService.performExistingAccountSetupFlows()
             .mapError({ error in
                 NetworkError.decodingError("")
@@ -209,7 +209,7 @@ final class UserDataMigrationInteractor: UserDataInteractor {
                                                                  code: authorizationCode)
                 
                 return socialLoginRepository.requestASToken(asTokenRequestDto: asTokenRequestDTO)
-            })            
+            })           
             .sink(receiveCompletion: { _ in
                 
             }, receiveValue: { _ in

--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor.swift
@@ -39,7 +39,10 @@ final class UserDataInteractorImpl: UserDataInteractor {
     ///  애플로그인을 요청합니다.
     /// - Parameter authorization: ASAuthorization
     func requestAppleLogin(_ authorization: ASAuthorization) {
-        guard let (email, idToken) = authService.requestAppleLogin(authorization) else {
+        guard let appleIDCredential = authService.requestAppleLogin(authorization),
+              let email = appleIDCredential.email,
+              let idTokenData = appleIDCredential.identityToken,
+              let idToken = String(data: idTokenData, encoding: .utf8) else {
             return
         }
         

--- a/HongikYeolgong2/Domain/Interactors/UserDataInteractor.swift
+++ b/HongikYeolgong2/Domain/Interactors/UserDataInteractor.swift
@@ -26,11 +26,11 @@ final class UserDataInteractorImpl: UserDataInteractor {
     private let cancleBag = CancelBag()
     private let appState: Store<AppState>
     private let authRepository: AuthRepository
-    private let authService: AppleLoginManager
+    private let authService: AppleLoginService
     
     init(appState: Store<AppState>,
          authRepository: AuthRepository,
-         authService: AppleLoginManager) {
+         authService: AppleLoginService) {
         self.appState = appState
         self.authRepository = authRepository
         self.authService = authService

--- a/HongikYeolgong2/Domain/Interfaces/SocialLoginRepository.swift
+++ b/HongikYeolgong2/Domain/Interfaces/SocialLoginRepository.swift
@@ -1,0 +1,10 @@
+//
+//  SocialLoginRepository.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/11/24.
+//
+
+import Foundation
+
+protocol SocialLoginRepository {}

--- a/HongikYeolgong2/Domain/Interfaces/SocialLoginRepository.swift
+++ b/HongikYeolgong2/Domain/Interfaces/SocialLoginRepository.swift
@@ -9,4 +9,5 @@ import Combine
 
 protocol SocialLoginRepository {
     func requestASToken(asTokenRequestDto: ASTokenRequestDTO) -> AnyPublisher<ASTokenResponseDTO, NetworkError>
+    func requestASTokenRevoke(asRevokeTokenRequestDto: ASRevokeTokenRequestDTO) -> AnyPublisher<Void, NetworkError>
 }

--- a/HongikYeolgong2/Domain/Interfaces/SocialLoginRepository.swift
+++ b/HongikYeolgong2/Domain/Interfaces/SocialLoginRepository.swift
@@ -5,6 +5,8 @@
 //  Created by 권석기 on 11/11/24.
 //
 
-import Foundation
+import Combine
 
-protocol SocialLoginRepository {}
+protocol SocialLoginRepository {
+    func requestASToken(asTokenRequestDto: ASTokenRequestDTO) -> AnyPublisher<ASTokenResponseDTO, NetworkError>
+}

--- a/HongikYeolgong2/Info.plist
+++ b/HongikYeolgong2/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppleAuthURL</key>
+	<string>$(APPLE_AUTH_URL)</string>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>NSAppTransportSecurity</key>

--- a/HongikYeolgong2/Info.plist
+++ b/HongikYeolgong2/Info.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AppleAuthURL</key>
-	<string>$(APPLE_AUTH_URL)</string>
+	<key>AppleIdURL</key>
+	<string>$(APPLEID_API_URL)</string>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>NSAppTransportSecurity</key>
@@ -17,6 +17,10 @@
 	<string>$(QNA_URL)</string>
 	<key>RoomStatusURL</key>
 	<string>$(ROOM_STATUS_URL)</string>
+	<key>ServiceID</key>
+	<string>$(SERVICE_ID)</string>
+	<key>TeamID</key>
+	<string>$(TEAM_ID)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>SUITE-SemiBold.otf</string>

--- a/HongikYeolgong2/Injected/DependencyInjector.swift
+++ b/HongikYeolgong2/Injected/DependencyInjector.swift
@@ -26,7 +26,7 @@ struct DIContainer: EnvironmentKey {
     
     private static let `default` = Self(appState: .init(AppState()),
                                         interactors: .default,
-                                        services: .init(appleAuthService: AuthenticationServiceImpl()))
+                                        services: .init(appleAuthService: AppleLoginManager()))
 }
 
 extension EnvironmentValues {

--- a/HongikYeolgong2/Injected/InteractorsContainer.swift
+++ b/HongikYeolgong2/Injected/InteractorsContainer.swift
@@ -39,7 +39,7 @@ extension DIContainer {
             userDataInteractor: UserDataInteractorImpl(
                 appState: Store<AppState>(AppState()),
                 authRepository: AuthRepositoryImpl(),
-                authService: AuthenticationServiceImpl()
+                authService: AppleLoginManager()
             ),
             studyTimeInteractor: StudyTimeInteractorImpl(studySessionRepository: StudySessionRepositoryImpl()),
             studySessionInteractor: StudySessionInteractorImpl(appState: Store<AppState>(AppState()), studySessionRepository: StudySessionRepositoryImpl()),

--- a/HongikYeolgong2/Presentation/Auth/Onboarding/Component/AppleLoginButton.swift
+++ b/HongikYeolgong2/Presentation/Auth/Onboarding/Component/AppleLoginButton.swift
@@ -1,0 +1,36 @@
+//
+//  AppleLoginButton.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/12/24.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct AppleLoginButton: View {
+    let onRequest: (ASAuthorizationAppleIDRequest) -> Void
+    let onCompletion: (Result<ASAuthorization, any Error>) -> Void
+    
+    var body: some View {
+        Button(action: {}) {
+            Image(.snsLogin)
+                .resizable()
+                .frame(maxWidth: .infinity, maxHeight: 52)
+        }
+        .padding(.horizontal, 32.adjustToScreenWidth)
+        .padding(.top, 32.adjustToScreenHeight)
+        .padding(.bottom, 20.adjustToScreenHeight)
+        .overlay(
+            SignInWithAppleButton(
+                onRequest: onRequest,
+                onCompletion: onCompletion
+            )
+            .blendMode(.destinationOver)
+        )
+    }
+}
+
+#Preview {
+    AppleLoginButton(onRequest: {_ in}, onCompletion: {_ in})
+}

--- a/HongikYeolgong2/Presentation/Auth/Onboarding/Component/OnboardingPageView.swift
+++ b/HongikYeolgong2/Presentation/Auth/Onboarding/Component/OnboardingPageView.swift
@@ -1,0 +1,45 @@
+//
+//  OnboardingPageView.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/12/24.
+//
+
+import SwiftUI
+
+struct OnboardingPageView: View {
+    @Binding var tabIndex: Int
+    
+    var body: some View {
+        VStack {
+            TabView(selection: $tabIndex) {
+                Image(.onboarding01)
+                    .tag(0)
+                Image(.onboarding02)
+                    .tag(1)
+                Image(.onboarding03)
+                    .tag(2)
+            }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+            
+            HStack(spacing: 16.adjustToScreenWidth) {
+                ForEach(0..<3, id: \.self) { index in
+                    Group {
+                        if index == tabIndex {
+                            Image(.shineCount02)
+                                .frame(width: 9, height: 9)
+                        } else {
+                            Circle()
+                                .frame(width: 9, height: 9)
+                                .foregroundColor(.gray600)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingPageView(tabIndex: .constant(0))
+}

--- a/HongikYeolgong2/Presentation/Auth/Onboarding/Component/OnboardingPageView.swift
+++ b/HongikYeolgong2/Presentation/Auth/Onboarding/Component/OnboardingPageView.swift
@@ -36,6 +36,7 @@ struct OnboardingPageView: View {
                     }
                 }
             }
+            
         }
     }
 }

--- a/HongikYeolgong2/Presentation/Auth/Onboarding/OnboardingView.swift
+++ b/HongikYeolgong2/Presentation/Auth/Onboarding/OnboardingView.swift
@@ -16,81 +16,26 @@ struct OnboardingView: View {
     // MARK: - Body
     var body: some View {
         NavigationStack {
-            content
-                .onReceive(routingUpdate) { routingState = $0 }
+            VStack {
+                Spacer()
+                OnboardingPageView(tabIndex: $tabIndex)
+                                
+                AppleLoginButton(
+                    onRequest: onRequestAppleLogin,
+                    onCompletion: onCompleteAppleLogin
+                )
+                
+                NavigationLink(
+                    destination: SignUpView(),
+                    isActive: routingBinding.signUp
+                ) {
+                    EmptyView()
+                }
+                .opacity(0)
+                .frame(width: 0, height: 0)
+            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
-    }
-    
-    // MARK: - Main Contents
-    private var content: some View {
-        VStack {
-            Spacer()
-            onboardingPageView
-            pageIndicator
-            appleLoginButton
-            hiddenNavigationLink
-        }
-    }
-    
-    // MARK: - UI Components
-    private var onboardingPageView: some View {
-        TabView(selection: $tabIndex) {
-            Image(.onboarding01)
-                .tag(0)
-            Image(.onboarding02)
-                .tag(1)
-            Image(.onboarding03)
-                .tag(2)
-        }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-    }
-    
-    private var pageIndicator: some View {
-        HStack(spacing: 16.adjustToScreenWidth) {
-            ForEach(0..<3, id: \.self) { index in
-                indicatorDot(for: index)
-            }
-        }
-    }
-    
-    private func indicatorDot(for index: Int) -> some View {
-        Group {
-            if index == tabIndex {
-                Image(.shineCount02)
-                    .frame(width: 9, height: 9)
-            } else {
-                Circle()
-                    .frame(width: 9, height: 9)
-                    .foregroundColor(.gray600)
-            }
-        }
-    }
-    
-    private var appleLoginButton: some View {
-        Button(action: {}) {
-            Image(.snsLogin)
-                .resizable()
-                .frame(maxWidth: .infinity, maxHeight: 52)
-        }
-        .padding(.horizontal, 32.adjustToScreenWidth)
-        .padding(.top, 32.adjustToScreenHeight)
-        .padding(.bottom, 20.adjustToScreenHeight)
-        .overlay(
-            SignInWithAppleButton(
-                onRequest: onRequestAppleLogin,
-                onCompletion: onCompleteAppleLogin
-            )
-            .blendMode(.destinationOver)
-        )
-    }
-    
-    private var hiddenNavigationLink: some View {
-        NavigationLink(destination: SignUpView(), isActive: routingBinding.signUp) {
-            EmptyView()
-        }
-        .opacity(0)
-        .frame(width: 0, height: 0)
     }
 }
 
@@ -123,3 +68,4 @@ extension OnboardingView {
         var signUp: Bool = false
     }
 }
+

--- a/HongikYeolgong2/Presentation/Auth/Onboarding/OnboardingView.swift
+++ b/HongikYeolgong2/Presentation/Auth/Onboarding/OnboardingView.swift
@@ -34,6 +34,7 @@ struct OnboardingView: View {
                 .opacity(0)
                 .frame(width: 0, height: 0)
             }
+            .onReceive(routingUpdate) { routingState = $0 }
         }
         .navigationViewStyle(StackNavigationViewStyle())
     }

--- a/HongikYeolgong2/Util/API/Base/NetworkService.swift
+++ b/HongikYeolgong2/Util/API/Base/NetworkService.swift
@@ -24,6 +24,23 @@ struct NetworkService: NetworkProtocol {
         
         return try processResponse(data: data, response: response)
     }        
+    
+    func plainRequest(endpoint: EndpointProtocol) async throws {
+        guard let url = configUrl(endpoint: endpoint) else {
+            throw NetworkError.invalidUrl
+        }
+        
+        let request = configRequest(url: url, endpoint: endpoint)
+        let (data, response) = try await session.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+        
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw NetworkError.serverError(statusCode: httpResponse.statusCode)
+        }
+    }
 }
 
 extension NetworkService {
@@ -66,7 +83,7 @@ extension NetworkService {
         guard (200...299).contains(httpResponse.statusCode) else {
             throw NetworkError.serverError(statusCode: httpResponse.statusCode)
         }
-        
+                
         do {
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/HongikYeolgong2/Util/API/Base/NetworkService.swift
+++ b/HongikYeolgong2/Util/API/Base/NetworkService.swift
@@ -23,7 +23,7 @@ struct NetworkService: NetworkProtocol {
         let (data, response) = try await session.data(for: request)
         
         return try processResponse(data: data, response: response)
-    }
+    }        
 }
 
 extension NetworkService {
@@ -66,13 +66,16 @@ extension NetworkService {
         guard (200...299).contains(httpResponse.statusCode) else {
             throw NetworkError.serverError(statusCode: httpResponse.statusCode)
         }
-        
+        if let jsonString = String(data: data, encoding: .utf8) {
+                print(jsonString)
+            }
         do {
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             
             return try decoder.decode(T.self, from: data)
         } catch {
+            print(error)
             throw NetworkError.decodingError(error.localizedDescription)
         }
     }

--- a/HongikYeolgong2/Util/API/Base/NetworkService.swift
+++ b/HongikYeolgong2/Util/API/Base/NetworkService.swift
@@ -66,9 +66,7 @@ extension NetworkService {
         guard (200...299).contains(httpResponse.statusCode) else {
             throw NetworkError.serverError(statusCode: httpResponse.statusCode)
         }
-        if let jsonString = String(data: data, encoding: .utf8) {
-                print(jsonString)
-            }
+        
         do {
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
+++ b/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
@@ -38,11 +38,13 @@ enum ASAuthEndpoint: EndpointProtocol {
         switch self {
         case let .requestToken(asTokenRequestDto):
             return [URLQueryItem(name: "client_id", value: asTokenRequestDto.client_id),
-             URLQueryItem(name: "client_secret", value: asTokenRequestDto.client_secret),
-             URLQueryItem(name: "code", value: asTokenRequestDto.code),
-             URLQueryItem(name: "grant_type", value: asTokenRequestDto.grant_type)]
+                    URLQueryItem(name: "client_secret", value: asTokenRequestDto.client_secret),
+                    URLQueryItem(name: "code", value: asTokenRequestDto.code),
+                    URLQueryItem(name: "grant_type", value: asTokenRequestDto.grant_type)]
         case let .requestRevoke(asRevokeTokenRequestDto):
-            return nil
+            return [URLQueryItem(name: "client_id", value: asRevokeTokenRequestDto.client_id),
+                    URLQueryItem(name: "client_secret", value: asRevokeTokenRequestDto.client_secret),
+                    URLQueryItem(name: "token", value: asRevokeTokenRequestDto.token)]
         }
     }
     

--- a/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
+++ b/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
@@ -9,10 +9,11 @@ import Foundation
 
 enum ASAuthEndpoint: EndpointProtocol {
     case requestToken(ASTokenRequestDTO)
+    case requestRevoke(ASRevokeTokenRequestDTO)
     
     var baseURL: URL? {
         switch self {
-        case .requestToken:
+        default:
             URL(string: "\(SecretKeys.appleIDApiUrl)")
         }
     }
@@ -21,12 +22,14 @@ enum ASAuthEndpoint: EndpointProtocol {
         switch self {
         case .requestToken:
             "/token"
+        case .requestRevoke:
+            "/revoke"
         }
     }
     
     var method: NetworkMethod {
         switch self {
-        case .requestToken:
+        case .requestToken, .requestRevoke:
                 .post
         }
     }
@@ -34,10 +37,12 @@ enum ASAuthEndpoint: EndpointProtocol {
     var parameters: [URLQueryItem]? {
         switch self {
         case let .requestToken(asTokenRequestDto):
-            [URLQueryItem(name: "client_id", value: asTokenRequestDto.client_id),
+            return [URLQueryItem(name: "client_id", value: asTokenRequestDto.client_id),
              URLQueryItem(name: "client_secret", value: asTokenRequestDto.client_secret),
              URLQueryItem(name: "code", value: asTokenRequestDto.code),
              URLQueryItem(name: "grant_type", value: asTokenRequestDto.grant_type)]
+        case let .requestRevoke(asRevokeTokenRequestDto):
+            return nil
         }
     }
     
@@ -50,7 +55,7 @@ enum ASAuthEndpoint: EndpointProtocol {
     
     var body: Data? {
         switch self {
-        case .requestToken:
+        case .requestToken, .requestRevoke:
             return nil
         }
     }

--- a/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
+++ b/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
@@ -1,0 +1,54 @@
+//
+//  ASAuthEndpoint.swift
+//  HongikYeolgong2
+//
+//  Created by 권석기 on 11/11/24.
+//
+
+import Foundation
+
+enum ASAuthEndpoint: EndpointProtocol {
+    case requestToken
+    
+    var baseURL: URL? {
+        switch self {
+        case .requestToken:
+            URL(string: "\(SecretKeys.appleAuthUrl)")
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .requestToken:
+            "/token"
+        }
+    }
+    
+    var method: NetworkMethod {
+        switch self {
+        case .requestToken:
+            .post
+        }
+    }
+    
+    var parameters: [URLQueryItem]? {
+        switch self {
+        case .requestToken:
+            nil
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        default:
+            ["Content-Type": "application/json", "form-data": "application/x-www-form-urlencoded"]
+        }
+    }
+    
+    var body: Data? {
+        switch self {
+        case .requestToken:
+            nil
+        }
+    }
+}

--- a/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
+++ b/HongikYeolgong2/Util/API/Endpoints/ASAuthEndpoint.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 enum ASAuthEndpoint: EndpointProtocol {
-    case requestToken
+    case requestToken(ASTokenRequestDTO)
     
     var baseURL: URL? {
         switch self {
         case .requestToken:
-            URL(string: "\(SecretKeys.appleAuthUrl)")
+            URL(string: "\(SecretKeys.appleIDApiUrl)")
         }
     }
     
@@ -27,28 +27,31 @@ enum ASAuthEndpoint: EndpointProtocol {
     var method: NetworkMethod {
         switch self {
         case .requestToken:
-            .post
+                .post
         }
     }
     
     var parameters: [URLQueryItem]? {
         switch self {
-        case .requestToken:
-            nil
+        case let .requestToken(asTokenRequestDto):
+            [URLQueryItem(name: "client_id", value: asTokenRequestDto.client_id),
+             URLQueryItem(name: "client_secret", value: asTokenRequestDto.client_secret),
+             URLQueryItem(name: "code", value: asTokenRequestDto.code),
+             URLQueryItem(name: "grant_type", value: asTokenRequestDto.grant_type)]
         }
     }
     
     var headers: [String : String]? {
         switch self {
         default:
-            ["Content-Type": "application/json", "form-data": "application/x-www-form-urlencoded"]
+            ["Content-Type": "application/x-www-form-urlencoded"]
         }
     }
     
     var body: Data? {
         switch self {
         case .requestToken:
-            nil
+            return nil
         }
     }
 }

--- a/HongikYeolgong2/Util/Constants.swift
+++ b/HongikYeolgong2/Util/Constants.swift
@@ -12,7 +12,10 @@ struct SecretKeys {
     static let roomStatusUrl = Bundle.main.infoDictionary?["RoomStatusURL"] as? String ?? ""
     static let noticeUrl = Bundle.main.infoDictionary?["NoticeURL"] as? String ?? ""
     static let qnaUrl = Bundle.main.infoDictionary?["QnaURL"] as? String ?? ""
-    static let appleAuthUrl = Bundle.main.infoDictionary?["AppleAuthURL"] as? String ?? ""
+    static let appleIDApiUrl = Bundle.main.infoDictionary?["AppleIdURL"] as? String ?? ""
+    static let bundleName = Bundle.main.bundleIdentifier ?? ""
+    static let teamID = Bundle.main.infoDictionary?["TeamID"] as? String ?? ""
+    static let serviceID = Bundle.main.infoDictionary?["ServiceID"] as? String ?? ""
 }
 
 

--- a/HongikYeolgong2/Util/Constants.swift
+++ b/HongikYeolgong2/Util/Constants.swift
@@ -12,6 +12,7 @@ struct SecretKeys {
     static let roomStatusUrl = Bundle.main.infoDictionary?["RoomStatusURL"] as? String ?? ""
     static let noticeUrl = Bundle.main.infoDictionary?["NoticeURL"] as? String ?? ""
     static let qnaUrl = Bundle.main.infoDictionary?["QnaURL"] as? String ?? ""
+    static let appleAuthUrl = Bundle.main.infoDictionary?["AppleAuthURL"] as? String ?? ""
 }
 
 

--- a/HongikYeolgong2/Util/Services/AppleLoginManager.swift
+++ b/HongikYeolgong2/Util/Services/AppleLoginManager.swift
@@ -9,23 +9,19 @@ import Foundation
 import AuthenticationServices
 
 protocol AppleLoginManager {
-    func requestAppleLogin(_ authrization: ASAuthorization) -> (email: String, idToken: String)?
+    func requestAppleLogin(_ authrization: ASAuthorization) -> ASAuthorizationAppleIDCredential?
 }
 
 final class AuthenticationServiceImpl: AppleLoginManager {
     
-    /// 애플로그인 요청을 위한 이메일과 토큰을 반환합니다.(이메일은 첫로그인시 반환)
+    /// 애플로그인 요청을 위한 AppleIDCredential 을 반환합니다.
     /// - Parameter authorization: authorization
-    /// - Returns: email, identityToken
-    func requestAppleLogin(_ authorization: ASAuthorization) -> (email: String, idToken: String)? {
-        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
-              let idTokenData = appleIDCredential.identityToken,
-              let idToken = String(data: idTokenData, encoding: .utf8) else {
+    /// - Returns: AppleIDCredential
+    func requestAppleLogin(_ authorization: ASAuthorization) -> ASAuthorizationAppleIDCredential? {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
             return nil
         }
         
-        let email = appleIDCredential.email ?? ""
-        
-        return (email: email, idToken: idToken)
+        return appleIDCredential
     }
 }


### PR DESCRIPTION
## AS-IS
회원탈퇴를 위해서 AppleID 서버로 탈퇴 요청을 보냅니다.
## TO-BE
회원탈퇴를 위해서 AppleID 서버로 탈퇴 요청을 보냅니다.
## KEY-POINT
회원탈퇴시 DB에서 유저정보를 삭제하고 추가적으로 유저의 Apple 계정에서 열공이 서비스를 완전히 삭제합니다.

- SwiftJWT 패키지 설치
- 회원탈퇴시 DB에서 유저정보를 삭제하기 전 AppleID Server로 토큰요청, 토큰삭제 과정을 거칩니다.
- 해당 과정이 완료되고 나서야 서버에 유저정보 삭제를 요청합니다.
- 회원탈퇴시 총 3번의 요청이 이루어지고 탈퇴가 완료됩니다.
- 총 3번의 연속적인 요청이 이전 요청 결과에 의존성을 가지기 때문에 flatMap으로 이전의 결과를 받아서 새로운 요청을 하도록 처리했습니다.
- 오류가 발생하는 경우 스트림이 중단됩니다. 이에대한 예외처리는 아직 처리하지 못했습니다.

**AppleLogin 메서드 추가**
```swift
protocol AppleLoginService {
    func requestAppleLogin(_ authrization: ASAuthorization) -> ASAuthorizationAppleIDCredential?
    func requestAppleLogin() -> AnyPublisher<ASAuthorizationAppleIDCredential?, Error>
    func performExistingAccountSetupFlows() -> AnyPublisher<ASAuthorizationAppleIDCredential?, Error>
}
```
로직 대부분이 Publisher를 체인해서 사용하고 있기때문에 AppleLogin관련 메서드또한 Publihser를 리턴하는 형태로 구현했습니다.

**보안문제**

출시전에 서버쪽에서 AppleID 회원탈퇴 까지는 제공이 어려울 것 같다고해서 협의하에 클라에서 처리를 했습니다. 그런데 아래와 같은 문제점이 발생합니다. 해당 기능은 출시후에 빠르게 서버로 이관을 했으면 좋겠습니다.

- 클라이언트 단에서 Token을 발급하고 요청함(보안상 문제)
- 토큰을 생성하는 과정에서 민감한 키들을 다룰일이 많아짐
- 토큰 관리와 갱신이 서버, 클라 양쪽에서 이루어짐
## SCREENSHOT (Optional)


https://github.com/user-attachments/assets/7e147768-a706-4b08-8c6e-3b62018920da

