### PR TITLE
[Fix] 타이머가 자동종료시 비정상적인 시간이 등록되는 현상

### DIFF
--- a/HongikYeolgong2/Domain/Interactors/StudySessionInteractor.swift
+++ b/HongikYeolgong2/Domain/Interactors/StudySessionInteractor.swift
@@ -24,7 +24,7 @@ final class StudySessionInteractorImpl: StudySessionInteractor {
     private let cancleBag = CancelBag()
     private let studySessionRepository: StudySessionRepository
     private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
-    private let addedTime: TimeInterval = .init(hours: 4)
+    private let addedTime: TimeInterval = .init(hours: 6)
     
     private var lastTime: Date?
     private var subscription: AnyCancellable?
@@ -74,7 +74,12 @@ final class StudySessionInteractorImpl: StudySessionInteractor {
         cancelAllNotification()
         
         let startTime: Date = appState.value.studySession.startTime
-        let endTime: Date = .now
+        let remainingTime = appState.value.studySession.remainingTime
+        // 최대시간
+        // 최근이용 시작시간 + 6시간
+        let maxEndTime = appState.value.studySession.startTime.addingTimeInterval(.init(hours: 6))
+        // 남은시간이 0인경우 최대시간 적용
+        let endTime: Date = remainingTime <= 0 ? maxEndTime : .now
         
         uploadStudySession(startTime: startTime, endTime: endTime)
     }


### PR DESCRIPTION
## AS-IS

## TO-BE
프로필편집 업데이트에 함께올라갈 예외처리 입니다.
## KEY-POINT
백그라운드 상태에서 타이머가 종료되는 경우 그즉시 올라가지않고 앱을 다시 실행하는 시점에 올라갑니다.
```swift
let maxEndTime = appState.value.studySession.startTime.addingTimeInterval(.init(hours: 6))
        // 남은시간이 0인경우 최대시간 적용
        let endTime: Date = remainingTime <= 0 ? maxEndTime : .now
        
        uploadStudySession(startTime: startTime, endTime: endTime)
```
남은시간이 0인경우 시작시간 + 최대시간(6시간)을 endTime에 저장합니다.
## SCREENSHOT (Optional)
