### PR TITLE
[Fix] RankingScreen 순서 위치를 기준으로 고정

### DIFF
--- a/HongikYeolgong2/Presentation/Ranking/Component/RankingCell.swift
+++ b/HongikYeolgong2/Presentation/Ranking/Component/RankingCell.swift
@@ -9,12 +9,17 @@ import SwiftUI
 
 struct RankingCell: View {
     let departmentRankInfo: RankingDepartment
+    let offset: Int
+    
+    var isStudyTimeLessThanZero: Bool {
+        departmentRankInfo.studyDurationOfWeek <= 0
+    }
     
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 HStack(spacing: 14.adjustToScreenWidth) {
-                    Text("\(departmentRankInfo.currentRank)")
+                    Text(isStudyTimeLessThanZero ? "-" : "\(departmentRankInfo.currentRank)")
                         .font(.pretendard(size: 16, weight: .regular))
                         .foregroundStyle(setFontColor)
                     
@@ -55,7 +60,7 @@ extension RankingCell {
     }
     
     private var setBackground: some View {
-        switch departmentRankInfo.currentRank {
+        switch offset {
         case 1:
             return Image(.rankingBox1)
                 .resizable()
@@ -76,7 +81,7 @@ extension RankingCell {
     }
     
     private var setFontColor: Color {
-        switch departmentRankInfo.currentRank {
+        switch offset {
         case 1:
                 .gray600
         case 2:

--- a/HongikYeolgong2/Presentation/Ranking/Component/RankingListView.swift
+++ b/HongikYeolgong2/Presentation/Ranking/Component/RankingListView.swift
@@ -13,8 +13,8 @@ struct RankingListView: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             LazyVStack(spacing: 16) {
-                ForEach(departmentRankings, id: \.self) { rankingInfo in
-                    RankingCell(departmentRankInfo: rankingInfo)
+                ForEach(Array(departmentRankings.enumerated()), id: \.self.offset) { (offset, rankingInfo) in
+                    RankingCell(departmentRankInfo: rankingInfo, offset: offset + 1)
                 }
             }
             .padding(.horizontal, 32.adjustToScreenWidth)


### PR DESCRIPTION
## AS-IS

## TO-BE
- #149 
## KEY-POINT
- 순서를 currentRanking이 아닌 위치(offset)를 기준으로 고정합니다
- 이용시간이 0인경우 순위를 문자 "-"로 대체합니다.
## SCREENSHOT (Optional)

<img src="https://github.com/user-attachments/assets/8c757dd1-8351-45cf-ae00-42b2d35eb35f" width=30%/>
변경전
<img src="https://github.com/user-attachments/assets/04888d89-99ad-4d35-8abf-8f229dd7b215" width=30%/>
변경후