### PR TITLE
[Fix] 랭킹 주차 표기 오류 수정

### DIFF
--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 			isa = PBXGroup;
 			children = (
 				5ED93CDA2CE3690D004A7931 /* Secrets-prod.xcconfig */,
+				981D050B2D6F69080058D0C5 /* Secrets-dev.xcconfig */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -1514,7 +1515,7 @@
 		};
 		47B1D4CB2C9CB1760071B62B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 981D050B2D6F69080058D0C5 /* Secrets-dev.xcconfig */;
+			baseConfigurationReference = 98A1F80F2D69D08C009B2DA6 /* Secrets-prod.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -1601,7 +1602,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamHY2.HongikYeolgong2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1618,7 +1619,7 @@
 		};
 		47B1D4CE2C9CB1760071B62B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 98A1F80E2D69D08C009B2DA6 /* Secrets-dev.xcconfig */;
+			baseConfigurationReference = 98A1F80F2D69D08C009B2DA6 /* Secrets-prod.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1648,7 +1649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamHY2.HongikYeolgong2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1690,7 +1691,7 @@
 		};
 		47B1D4D12C9CB1760071B62B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 98A1F80E2D69D08C009B2DA6 /* Secrets-dev.xcconfig */;
+			baseConfigurationReference = 98A1F80F2D69D08C009B2DA6 /* Secrets-prod.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -1735,7 +1736,7 @@
 		};
 		47B1D4D42C9CB1760071B62B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 98A1F80E2D69D08C009B2DA6 /* Secrets-dev.xcconfig */;
+			baseConfigurationReference = 98A1F80F2D69D08C009B2DA6 /* Secrets-prod.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/HongikYeolgong2.xcodeproj/project.pbxproj
+++ b/HongikYeolgong2.xcodeproj/project.pbxproj
@@ -1602,7 +1602,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamHY2.HongikYeolgong2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1649,7 +1649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.7;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teamHY2.HongikYeolgong2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/HongikYeolgong2/Domain/Interactors/RankingDataInteractor.swift
+++ b/HongikYeolgong2/Domain/Interactors/RankingDataInteractor.swift
@@ -79,7 +79,7 @@ final class RankingDataInteractorImpl: RankingDataInteractor {
     
     // 연도별 주차 추출 (24년 10주차 -> 202410 형태)
     func getWeekOfYear(date: Date) -> Int {
-        var calendar = Calendar.current
+        var calendar = Calendar(identifier: .iso8601)
         calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         
         let weekOfYear = calendar.component(.weekOfYear, from: date)
@@ -91,7 +91,7 @@ final class RankingDataInteractorImpl: RankingDataInteractor {
     
     // 주차 이동 후 연도별 주차 반환
     func changeWeek(by offset: Int) -> Int {
-        var calendar = Calendar.current
+        var calendar = Calendar(identifier: .iso8601)
         calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         baseDate = calendar.date(byAdding: .weekOfYear, value: offset, to: baseDate) ?? baseDate
         

--- a/HongikYeolgong2/Domain/Interactors/RankingDataInteractor.swift
+++ b/HongikYeolgong2/Domain/Interactors/RankingDataInteractor.swift
@@ -9,18 +9,16 @@ import SwiftUI
 import Combine
 
 protocol RankingDataInteractor {
-    func getCurrentWeeklyRanking(weeklyRanking: Binding<WeeklyRanking>)
-    func getNextWeeklyRanking(weeklyRanking: Binding<WeeklyRanking>)
-    func getPreviosWeeklyRanking(weeklyRanking: Binding<WeeklyRanking>)
+    func getWeeklyRanking()
 }
 
-final class RankingDataInteractorImpl: RankingDataInteractor {
+final class RankingDataInteractorImpl: RankingDataInteractor, ObservableObject {
     let studySessionRepository: StudySessionRepository
     let weeklyRepository: WeeklyRepository
     let cancleBag = CancelBag()
     
-    // 랭킹 기준 날짜
-    var baseDate: Date = Date()
+    @Published var weeklyRanking: WeeklyRanking = WeeklyRanking()
+    @Published var baseDate: Date = Date()
     
     init(studySessionRepository: StudySessionRepository, weeklyRepository: WeeklyRepository) {
         self.studySessionRepository = studySessionRepository
@@ -29,50 +27,15 @@ final class RankingDataInteractorImpl: RankingDataInteractor {
     
     /// 현재 주차의 주간 랭킹을 가져오는 메서드
     /// - Parameter weeklyRanking: 주간 랭킹 데이터 리스트
-    func getCurrentWeeklyRanking(weeklyRanking: Binding<WeeklyRanking>) {
+    func getWeeklyRanking() {
         let weekNumber = getWeekOfYear(date: baseDate)
         
         studySessionRepository
             .getWeeklyRanking(weekNumber: weekNumber)
             .receive(on: DispatchQueue.main)
-            .sink { _ in
-                
-            } receiveValue: {
-                weeklyRanking.wrappedValue = $0
-            }
-            .store(in: cancleBag)
-    }
-    
-    /// 다음 주차의 주간 랭킹을 가져오는 메서드
-    /// - Parameter weeklyRanking: 주간 랭킹 데이터 리스트
-    func getNextWeeklyRanking(weeklyRanking: Binding<WeeklyRanking>) {
-        // 기존 날짜 +1주일
-        let weekNumber = changeWeek(by: 1)
-        
-        studySessionRepository
-            .getWeeklyRanking(weekNumber: weekNumber)
-            .receive(on: DispatchQueue.main)
-            .sink { _ in
-                
-            } receiveValue: {
-                weeklyRanking.wrappedValue = $0
-            }
-            .store(in: cancleBag)
-    }
-    
-    /// 이전 주차의 주간 랭킹을 가져오는 메서드
-    /// - Parameter weeklyRanking: 주간 랭킹 데이터 리스트
-    func getPreviosWeeklyRanking(weeklyRanking: Binding<WeeklyRanking>) {
-        // 기존 날짜 -1주일
-        let weekNumber = changeWeek(by: -1)
-        
-        studySessionRepository
-            .getWeeklyRanking(weekNumber: weekNumber)
-            .receive(on: DispatchQueue.main)
-            .sink { _ in
-                
-            } receiveValue: {
-                weeklyRanking.wrappedValue = $0
+            .sink { _ in }
+            receiveValue: {
+                self.weeklyRanking = $0
             }
             .store(in: cancleBag)
     }
@@ -89,13 +52,20 @@ final class RankingDataInteractorImpl: RankingDataInteractor {
         return year * 100 + weekOfYear
     }
     
-    // 주차 이동 후 연도별 주차 반환
-    func changeWeek(by offset: Int) -> Int {
+    // 주차 이동 후 랭킹 데이터 불러오기
+    func changeWeek(by offset: Int) {
         var calendar = Calendar(identifier: .iso8601)
         calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
         baseDate = calendar.date(byAdding: .weekOfYear, value: offset, to: baseDate) ?? baseDate
         
         print("baseDate: \(baseDate)")
-        return getWeekOfYear(date: baseDate)
+        // 주차 이동 후 데이터 불러오기
+        getWeeklyRanking()
+    }
+    
+    // 미래 주차 필터링
+    func isNextWeekAvailable() -> Bool {
+        let today = Date()
+        return baseDate.formattedFullDate() != today.formattedFullDate()
     }
 }

--- a/HongikYeolgong2/Presentation/Ranking/RankingView.swift
+++ b/HongikYeolgong2/Presentation/Ranking/RankingView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct RankingView: View {
-    @Environment(\.injected.interactors.rankingDataInteractor) var rankingDataInteractor
-    @State private var yearWeek = 0
-    @State private var weeklyRanking: WeeklyRanking = WeeklyRanking()
+    @StateObject private var rankingDataInteractor = RankingDataInteractorImpl(
+            studySessionRepository: StudySessionRepositoryImpl(),
+            weeklyRepository: WeeklyRepositoryImpl()
+        )
     
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                Text(weeklyRanking.weekName)
+                Text(rankingDataInteractor.weeklyRanking.weekName)
                     .font(.suite(size: 24, weight: .bold), lineHeight: 30.adjustToScreenHeight)
                     .foregroundColor(.gray100)
                 
@@ -23,17 +24,18 @@ struct RankingView: View {
                 
                 HStack(spacing: 7.adjustToScreenWidth) {
                     Button(action: {
-                        getPreviosWeeklyRanking()
+                        rankingDataInteractor.changeWeek(by: -1)
                     }, label: {
                         Image(.icCalendarLeft)
                     })
                     .frame(width: 36.adjustToScreenWidth, height: 36.adjustToScreenHeight)
                     
                     Button(action: {
-                        getNextWeeklyRanking()
+                        rankingDataInteractor.changeWeek(by: 1)
                     }, label: {
-                        Image(.icCalendarRight)
+                        Image(rankingDataInteractor.isNextWeekAvailable() ? .icCalendarRight : .isCalendarRightDisabled)
                     })
+                    .disabled(!rankingDataInteractor.isNextWeekAvailable())
                     .frame(width: 36.adjustToScreenWidth, height: 36.adjustToScreenHeight)
                 }
             }            
@@ -42,7 +44,7 @@ struct RankingView: View {
                                 bottom: 17.adjustToScreenHeight,
                                 trailing: 32.adjustToScreenWidth))
             
-            RankingListView(departmentRankings: weeklyRanking.departmentRankings)
+            RankingListView(departmentRankings: rankingDataInteractor.weeklyRanking.departmentRankings)
         }
         .onAppear {
             getCurrentWeeklyRanking()
@@ -51,14 +53,6 @@ struct RankingView: View {
     }
     
     func getCurrentWeeklyRanking() {
-        rankingDataInteractor.getCurrentWeeklyRanking(weeklyRanking: $weeklyRanking)
-    }
-    
-    func getNextWeeklyRanking() {
-        rankingDataInteractor.getNextWeeklyRanking(weeklyRanking: $weeklyRanking)
-    }
-    
-    func getPreviosWeeklyRanking() {
-        rankingDataInteractor.getPreviosWeeklyRanking(weeklyRanking: $weeklyRanking)
+        rankingDataInteractor.getWeeklyRanking()
     }
 }


### PR DESCRIPTION
## AS-IS
- 랭킹부분 주차 표기 오류 발생
- 미래 주차 이동 가능
## TO-BE
- #163 
## KEY-POINT
- 랭킹부분 날짜 기반 연도 주차 받아오는 기준값 수정
- 미래 주차 이동 방지
  - Interactor에서 Binding 대신 @Published를 사용하여 데이터 관리
  - StateObject를 활용해 RankingView에서 Interactor를 관찰하도록 변경
  

## SCREENSHOT (Optional)
